### PR TITLE
chore: apply Maestro layout migration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -77,6 +77,7 @@ examples/
 
 # Maestro workflow
 /.claude/
+/.maestro/project/
 /.maestro/generated/
 /.maestro/state/
 /.maestro/cache/


### PR DESCRIPTION
## Summary
- update the Maestro source submodule to the merged layout review fixes
- run the v2 layout migration locally
- ignore .maestro/project so migrated project config and overrides stay local with generated/state/cache/backups

## Verification
- .maestro/source/scripts/reconcile-layout.sh migrate --apply
- .maestro/source/scripts/reconcile-layout.sh check
- .maestro/source/scripts/reconcile-layout.sh plan
- git diff --check

## Notes
The migration moved local Maestro files into .maestro/project and .maestro/state. Those paths are intentionally ignored; the tracked PR only records the source pointer and ignore coverage. .claude remains the configured generated projection and is skipped because .maestro/generated/claude exists.